### PR TITLE
Update Dockerfile for Node 22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,16 @@
 FROM node:22-alpine AS base
 WORKDIR /app
+
+# Install build tools for native modules
+RUN apk add --no-cache python3 make g++ sqlite-dev
+
 COPY package*.json ./
-RUN npm install --production
+RUN npm install --production \
+    && npm rebuild sqlite3 --build-from-source \
+    && npm install -g @openai/codex
+
 COPY . .
 RUN npm run build
-CMD ["node","dist/main.js"]
+
+EXPOSE 8123
+CMD ["node", "dist/main.js"]


### PR DESCRIPTION
## Summary
- add build dependencies for `sqlite3` and the Codex CLI
- globally install `@openai/codex`
- rebuild `sqlite3` for Node 22
- expose port 8123 for the HTTP/WS server

## Testing
- `npm test`