### PR TITLE
Allow configurable rate limit RPM

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -27,6 +27,7 @@
 * **OPENAI_API_KEY** – API key for Codex
 * **JWT_SECRET** – secret used for JWT signing
 * **CAPABILITIES_FILE** – JSON file describing available tools
+* **RATE_LIMIT_RPM** – max requests per minute per agent (default 60)
 
 ### About storage
 Default backend is Redis but SQLite can be selected. Redis is used for:

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@
 
 * **OPENAI\_API\_KEY** – Codex 用 OpenAI キー
 * **JWT\_SECRET** – JWT 署名用シークレット（任意文字列）
+* **RATE_LIMIT_RPM** – 1 分あたりの最大リクエスト数 (デフォルト 60)
 
 ### ストレージについて
 デフォルトでは Redis を使用しますが、軽量な用途では SQLite も選択可能です。

--- a/src/config.ts
+++ b/src/config.ts
@@ -20,7 +20,9 @@ function loadConfig() {
     },
     redis: { url: process.env.REDIS_URL || 'redis://localhost:6379' },
     codex: { model: 'codex-1', apiKey: process.env.OPENAI_API_KEY },
-    rateLimit: { rpm: 60 },
+    rateLimit: {
+      rpm: parseInt(process.env.RATE_LIMIT_RPM || '60', 10)
+    },
     capabilitiesFile: process.env.CAPABILITIES_FILE || './capabilities.json'
   };
 }

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -5,3 +5,12 @@ test('config caching', () => {
   const b = config();
   expect(a).toBe(b);
 });
+
+test('rpm reads from env', () => {
+  jest.resetModules();
+  process.env.RATE_LIMIT_RPM = '42';
+  const cfg = require('../src/config.ts').default();
+  expect(cfg.rateLimit.rpm).toBe(42);
+  delete process.env.RATE_LIMIT_RPM;
+  jest.resetModules();
+});


### PR DESCRIPTION
## Summary
- read RATE_LIMIT_RPM from environment in config
- test rate limit configuration
- document RATE_LIMIT_RPM variable in README and README.en

## Testing
- `npm test`