### PR TITLE
Fix redis port inconsistencies

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -121,7 +121,7 @@ cat <<EOS > .env
 OPENAI_API_KEY=sk-...
 JWT_SECRET=mywrappersecret
 STORAGE_DRIVER=redis       # redis or sqlite
-REDIS_URL=redis://localhost:6380
+REDIS_URL=redis://localhost:6379
 SQLITE_DB=./wrapper.sqlite
 RATE_LIMIT_RPM=60
 EOS

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ $ cat <<EOF > .env
 OPENAI_API_KEY=sk-...
 JWT_SECRET=mywrappersecret
 STORAGE_DRIVER=redis       # redis または sqlite
-REDIS_URL=redis://localhost:6380
+REDIS_URL=redis://localhost:6379
 SQLITE_DB=./wrapper.sqlite
 RATE_LIMIT_RPM=60
 CAPABILITIES_FILE=./capabilities.json

--- a/env.example
+++ b/env.example
@@ -9,7 +9,7 @@ SQLITE_DB=./wrapper.sqlite  # SQLite データベースファイルのパス
 
 # Redis Configuration
 REDIS_PORT=6379           # Redis内部ポート（デフォルト）
-REDIS_EXTERNAL_PORT=6380  # 外部からアクセスするためのポート
+REDIS_EXTERNAL_PORT=6379  # 外部からアクセスするためのポート
 
 # Rate Limiting
 RATE_LIMIT_RPM=60         # 1分あたりのリクエスト数制限


### PR DESCRIPTION
## Summary
- pick port 6379 for Redis
- update env.example and READMEs to use `redis://localhost:6379`

## Testing
- `npm test`