### PR TITLE
Support standard MCP tools/list method

### DIFF
--- a/src/modules/mcp/mcp.service.ts
+++ b/src/modules/mcp/mcp.service.ts
@@ -48,7 +48,7 @@ export class McpService {
       }
       
       // Example of other MCP method handlers
-      if (message.method === 'listTools') {
+      if (message.method === 'tools/list' || message.method === 'listTools') {
         return this.handleListTools(message);
       }
       

--- a/tests/mcp.service.test.js
+++ b/tests/mcp.service.test.js
@@ -10,8 +10,8 @@ const token = jwt.sign({ user: 'test' }, process.env.JWT_SECRET);
 
 const mcp = new McpService(new MockCodexService());
 
-test('listTools returns tool list', async () => {
-  const body = { method: 'listTools', params: {}, id: '123' };
+test('tools/list returns tool list', async () => {
+  const body = { method: 'tools/list', params: {}, id: '123' };
   const res = await mcp.processMessage('session', body, token);
   expect(res.tools[0].name).toBe('codex');
 });


### PR DESCRIPTION
## Summary
- add `tools/list` alias to `McpService.processMessage`
- update unit test to use `tools/list`

## Testing
- `npm test`
- `npm run build`