### PR TITLE
Add job status endpoint

### DIFF
--- a/src/modules/codex/codex.service.ts
+++ b/src/modules/codex/codex.service.ts
@@ -24,4 +24,16 @@ export class CodexService {
       throw error;
     }
   }
+
+  /**
+   * ジョブ情報を取得
+   */
+  async getJob(id: string) {
+    try {
+      return await this.storage.getJob(id);
+    } catch (error: any) {
+      this.logger.error(`Failed to get job '${id}': ${error.message}`, error.stack);
+      throw error;
+    }
+  }
 }

--- a/src/modules/rpc/rpc.controller.ts
+++ b/src/modules/rpc/rpc.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, Post, Get, Param } from '@nestjs/common';
 import { CodexService } from '../codex/codex.service';
 import { LimiterService } from '../rate-limit/limiter.service';
 
@@ -25,5 +25,11 @@ export class RpcController {
     await this.limiter.hit(key);
     const job = await this.codex.enqueue(method, { args: params.args, wsId: params.wsId });
     return { id, jobId: job.id };
+  }
+
+  @Get('job/:id')
+  async getJob(@Param('id') jobId: string) {
+    await this.limiter.hit('codex_job_lookup');
+    return await this.codex.getJob(jobId);
   }
 }

--- a/src/modules/storage/interface.ts
+++ b/src/modules/storage/interface.ts
@@ -24,4 +24,11 @@ export interface IStorage {
    * @throws Error - レート制限を超えた場合
    */
   hitRate(key: string): Promise<void>;
-} 
+
+  /**
+   * 指定したジョブIDの情報を取得
+   * @param id - ジョブID
+   * @returns ジョブ情報、存在しない場合は null
+   */
+  getJob(id: string): Promise<any | null>;
+}

--- a/src/modules/storage/redis.storage.ts
+++ b/src/modules/storage/redis.storage.ts
@@ -82,4 +82,30 @@ export class RedisStorage implements IStorage {
       throw new Error(`Rate limiting error: ${error.message}`);
     }
   }
-} 
+
+  /**
+   * BullMQからジョブの状態を取得
+   */
+  async getJob(id: string) {
+    try {
+      const job = await this.queue.getJob(id);
+      if (!job) return null;
+      const state = await job.getState();
+      let returnvalue: any;
+      try {
+        returnvalue = await job.getReturnValue();
+      } catch {
+        returnvalue = undefined;
+      }
+      return {
+        id: job.id?.toString(),
+        state,
+        data: job.data,
+        returnvalue,
+      };
+    } catch (error: any) {
+      this.logger.error(`Failed to get job '${id}': ${error.message}`, error.stack);
+      throw error;
+    }
+  }
+}

--- a/src/modules/storage/sqlite.storage.ts
+++ b/src/modules/storage/sqlite.storage.ts
@@ -183,4 +183,23 @@ export class SqliteStorage implements IStorage {
       throw error;
     }
   }
-} 
+
+  /**
+   * ジョブ情報を取得
+   */
+  async getJob(id: string) {
+    if (!this.db) {
+      throw new Error('SQLite database not initialized');
+    }
+
+    try {
+      return await this.db.get(
+        `SELECT id, type, data, status FROM jobs WHERE id = ?`,
+        id
+      );
+    } catch (error: any) {
+      this.logger.error(`Failed to get job ${id}: ${error.message}`, error.stack);
+      throw error;
+    }
+  }
+}

--- a/tests/codex.service.test.js
+++ b/tests/codex.service.test.js
@@ -1,0 +1,12 @@
+const { CodexService } = require('../src/modules/codex/codex.service.ts');
+
+class MockStorage {
+  async getJob(id) { return { id, status: 'completed' }; }
+}
+
+test('getJob forwards to storage', async () => {
+  const svc = new CodexService(new MockStorage());
+  const job = await svc.getJob('j1');
+  expect(job.id).toBe('j1');
+  expect(job.status).toBe('completed');
+});

--- a/tests/rpc.controller.test.js
+++ b/tests/rpc.controller.test.js
@@ -1,0 +1,15 @@
+const { RpcController } = require('../src/modules/rpc/rpc.controller.ts');
+
+class MockCodex {
+  async enqueue() {}
+  async getJob(id) { return { id }; }
+}
+class MockLimiter {
+  async hit() {}
+}
+
+test('getJob endpoint returns job info', async () => {
+  const ctrl = new RpcController(new MockCodex(), new MockLimiter());
+  const res = await ctrl.getJob('xyz');
+  expect(res.id).toBe('xyz');
+});


### PR DESCRIPTION
## Summary
- expose job retrieval in storage classes
- add `getJob` helper in Codex service
- add `/rpc/job/:id` endpoint
- cover new logic with unit tests

## Testing
- `npm test`